### PR TITLE
Add `dictionaries` property in client class.

### DIFF
--- a/docs/source/full-docs.rst
+++ b/docs/source/full-docs.rst
@@ -55,6 +55,9 @@ Models
 .. autoclass:: vulcan._message.MessageRecipient
     :members:
 
+.. autoclass:: vulcan._dictionaries.Dictionaries
+    :members:
+
 Enum models
 ^^^^^^^^^^^
 

--- a/tests/test_dictionaries.py
+++ b/tests/test_dictionaries.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+
+from .utils import (
+    PARAMS_DICTIONARIES_TEACHERS,
+    PARAMS_DICTIONARIES_SUBJECTS,
+    PARAMS_DICTIONARIES_LESSON_TIMES,
+    PARAMS_DICTIONARIES_GRADE_CATEGORIES,
+)
+
+
+@pytest.mark.private
+class TestDictionaries:
+    @pytest.mark.parametrize("_id, login_id, short", PARAMS_DICTIONARIES_TEACHERS)
+    def test_teachers(self, client, _id, login_id, short):
+        teacher = next(filter(lambda t: t.id == _id, client.dictionaries.teachers))
+        assert teacher.short == short
+        assert teacher.login_id == login_id
+
+    @pytest.mark.parametrize("_id, name, short, position", PARAMS_DICTIONARIES_SUBJECTS)
+    def test_subjects(self, client, _id, name, short, position):
+        subject = next(filter(lambda s: s.id == _id, client.dictionaries.subjects))
+        assert subject.name == name
+        assert subject.short == short
+        assert subject.position == position
+
+    @pytest.mark.parametrize("_id, number, from_, to", PARAMS_DICTIONARIES_LESSON_TIMES)
+    def test_lesson_times(self, client, _id, number, from_, to):
+        lesson_time = next(
+            filter(lambda t: t.id == _id, client.dictionaries.lesson_times)
+        )
+        assert lesson_time.number == number
+        assert lesson_time.from_.strftime("%H:%M") == from_
+        assert lesson_time.to.strftime("%H:%M") == to
+
+    @pytest.mark.parametrize("_id, short, name", PARAMS_DICTIONARIES_GRADE_CATEGORIES)
+    def test_grade_categories(self, client, _id, short, name):
+        grade_category = next(
+            filter(lambda c: c.id == _id, client.dictionaries.grade_categories)
+        )
+        assert grade_category.short == short
+        assert grade_category.name == name

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -84,6 +84,26 @@ PARAMS_MESSAGES = [
     )
 ]
 
+PARAMS_DICTIONARIES_TEACHERS = [(85, 477, "ET"), (91, 482, "GD"), (95, 491, "MK")]
+
+PARAMS_DICTIONARIES_SUBJECTS = [
+    (115, "Religia", "religia", 0),
+    (118, "Język polski", "j. polski", 2),
+    (170, "Wiedza o społeczeństwie", "wos", 7),
+]
+
+PARAMS_DICTIONARIES_LESSON_TIMES = [
+    (36, 1, "08:15", "09:00"),
+    (37, 2, "09:10", "09:55"),
+    (42, 7, "13:55", "14:40"),
+]
+
+PARAMS_DICTIONARIES_GRADE_CATEGORIES = [
+    (15, "Akt", "Aktywność na lekcji"),
+    (31, "Proj", "Projekt długoterminowy do domu"),
+    (32, "PL", "Praca na lekcji"),
+]
+
 
 def load_variable(name):
     return environ.get(name)

--- a/vulcan/_dictionaries.py
+++ b/vulcan/_dictionaries.py
@@ -2,42 +2,68 @@
 
 from related import immutable, SequenceField, to_model
 
+from ._grade import GradeCategory
+from ._lesson import LessonTime
+from ._subject import Subject
+from ._teacher import Teacher
 from ._utils import find
 
 
 @immutable
 class Dictionaries:
-    teachers = SequenceField(dict, key="Pracownicy")
-    subjects = SequenceField(dict, key="Przedmioty")
-    lesson_times = SequenceField(dict, key="PoryLekcji")
-    grade_categories = SequenceField(dict, key="KategorieOcen")
-    notice_categories = SequenceField(dict, key="KategorieUwag")
-    attendance_categories = SequenceField(dict, key="KategorieFrekwencji")
-    attendance_types = SequenceField(dict, key="TypyFrekwencji")
+    teachers_json = SequenceField(dict, key="Pracownicy")
+    subjects_json = SequenceField(dict, key="Przedmioty")
+    lesson_times_json = SequenceField(dict, key="PoryLekcji")
+    grade_categories_json = SequenceField(dict, key="KategorieOcen")
+    notice_categories_json = SequenceField(dict, key="KategorieUwag")
+    attendance_categories_json = SequenceField(dict, key="KategorieFrekwencji")
+    attendance_types_json = SequenceField(dict, key="TypyFrekwencji")
 
-    def get_teacher(self, _id):
-        return find(self.teachers, _id)
+    @property
+    def teachers(self):
+        """list(:class:`vulcan._teacher.Teacher`): List of teachers"""
+        return list(map(lambda j: to_model(Teacher, j), self.teachers_json))
 
-    def get_teacher_login_id(self, _id):
-        return find(self.teachers, _id, key="LoginId")
+    @property
+    def subjects(self):
+        """list(:class:`vulcan._subject.Subject`): List of subjects"""
+        return list(map(lambda j: to_model(Subject, j), self.subjects_json))
 
-    def get_subject(self, _id):
-        return find(self.subjects, _id)
+    @property
+    def lesson_times(self):
+        """list(:class:`vulcan._lesson.LessonTime`): List of lesson times"""
+        return list(map(lambda j: to_model(LessonTime, j), self.lesson_times_json))
 
-    def get_lesson_time(self, _id):
-        return find(self.lesson_times, _id)
+    @property
+    def grade_categories(self):
+        """list(:class:`vulcan._grade.GradeCategory`): List of grade categories"""
+        return list(
+            map(lambda j: to_model(GradeCategory, j), self.grade_categories_json)
+        )
 
-    def get_grade_category(self, _id):
-        return find(self.grade_categories, _id)
+    def get_teacher_json(self, _id):
+        return find(self.teachers_json, _id)
 
-    def get_notice_category(self, _id):
-        return find(self.notice_categories, _id)
+    def get_teacher_by_login_id_json(self, _id):
+        return find(self.teachers_json, _id, key="LoginId")
 
-    def get_attendance_category(self, _id):
-        return find(self.attendance_categories, _id)
+    def get_subject_json(self, _id):
+        return find(self.subjects_json, _id)
 
-    def get_attendance_type(self, _id):
-        return find(self.attendance_types, _id)
+    def get_lesson_time_json(self, _id):
+        return find(self.lesson_times_json, _id)
+
+    def get_grade_category_json(self, _id):
+        return find(self.grade_categories_json, _id)
+
+    def get_notice_category_json(self, _id):
+        return find(self.notice_categories_json, _id)
+
+    def get_attendance_category_json(self, _id):
+        return find(self.attendance_categories_json, _id)
+
+    def get_attendance_type_json(self, _id):
+        return find(self.attendance_types_json, _id)
 
     @classmethod
     def get(cls, api):

--- a/vulcan/_exam.py
+++ b/vulcan/_exam.py
@@ -66,7 +66,7 @@ class Exam:
         exams = sort_and_filter_date(j.get("Data", []), date_str)
 
         for exam in exams:
-            exam["teacher"] = api.dict.get_teacher(exam["IdPracownik"])
-            exam["subject"] = api.dict.get_subject(exam["IdPrzedmiot"])
+            exam["teacher"] = api.dict.get_teacher_json(exam["IdPracownik"])
+            exam["subject"] = api.dict.get_subject_json(exam["IdPrzedmiot"])
 
             yield to_model(cls, exam)

--- a/vulcan/_grade.py
+++ b/vulcan/_grade.py
@@ -65,8 +65,8 @@ class Grade:
         j = api.post("Uczen/Oceny")
 
         for grade in j.get("Data", []):
-            grade["teacher"] = api.dict.get_teacher(grade["IdPracownikD"])
-            grade["subject"] = api.dict.get_subject(grade["IdPrzedmiot"])
-            grade["category"] = api.dict.get_grade_category(grade["IdKategoria"])
+            grade["teacher"] = api.dict.get_teacher_json(grade["IdPracownikD"])
+            grade["subject"] = api.dict.get_subject_json(grade["IdPrzedmiot"])
+            grade["category"] = api.dict.get_grade_category_json(grade["IdKategoria"])
 
             yield to_model(cls, grade)

--- a/vulcan/_homework.py
+++ b/vulcan/_homework.py
@@ -49,7 +49,7 @@ class Homework:
         homework_list = sort_and_filter_date(j.get("Data", []), date_str)
 
         for homework in homework_list:
-            homework["teacher"] = api.dict.get_teacher(homework["IdPracownik"])
-            homework["subject"] = api.dict.get_subject(homework["IdPrzedmiot"])
+            homework["teacher"] = api.dict.get_teacher_json(homework["IdPracownik"])
+            homework["subject"] = api.dict.get_subject_json(homework["IdPrzedmiot"])
 
             yield to_model(cls, homework)

--- a/vulcan/_lesson.py
+++ b/vulcan/_lesson.py
@@ -84,8 +84,8 @@ class Lesson:
         lessons = list(filter(lambda x: x["DzienTekst"] == date_str, lessons))
 
         for lesson in lessons:
-            lesson["time"] = api.dict.get_lesson_time(lesson["IdPoraLekcji"])
-            lesson["teacher"] = api.dict.get_teacher(lesson["IdPracownik"])
-            lesson["subject"] = api.dict.get_subject(lesson["IdPrzedmiot"])
+            lesson["time"] = api.dict.get_lesson_time_json(lesson["IdPoraLekcji"])
+            lesson["teacher"] = api.dict.get_teacher_json(lesson["IdPracownik"])
+            lesson["subject"] = api.dict.get_subject_json(lesson["IdPrzedmiot"])
 
             yield to_model(cls, lesson)

--- a/vulcan/_message.py
+++ b/vulcan/_message.py
@@ -78,5 +78,7 @@ class Message:
         messages = j.get("Data", [])
 
         for message in messages:
-            message["sender"] = api.dict.get_teacher_login_id(message["NadawcaId"])
+            message["sender"] = api.dict.get_teacher_by_login_id_json(
+                message["NadawcaId"]
+            )
             yield to_model(cls, message)

--- a/vulcan/_subject.py
+++ b/vulcan/_subject.py
@@ -12,8 +12,10 @@ class Subject:
         id (:class:`int`): Subject ID
         name (:class:`str`): Subject full name
         short (:class:`str`): Short name of the subject
+        position (:class:`int`) Position of the subject in subjects list
     """
 
     id = IntegerField(key="Id")
     name = StringField(key="Nazwa")
     short = StringField(key="Kod")
+    position = IntegerField(key="Pozycja")

--- a/vulcan/_vulcan.py
+++ b/vulcan/_vulcan.py
@@ -75,6 +75,16 @@ class Vulcan:
         """
         self._api.set_student(student)
 
+    @property
+    def dictionaries(self):
+        """
+        Dictionaries, that include i.a. teachers
+
+        Returns:
+            :class:`vulcan._dictionaries.Dictionaries`
+        """
+        return self._api.dict
+
     def get_grades(self):
         """
         Fetches student grades

--- a/vulcan/_vulcan.py
+++ b/vulcan/_vulcan.py
@@ -78,10 +78,7 @@ class Vulcan:
     @property
     def dictionaries(self):
         """
-        Dictionaries, that include i.a. teachers
-
-        Returns:
-            :class:`vulcan._dictionaries.Dictionaries`
+        :class:`vulcan._dictionaries.Dictionaries`: Dictionaries, that include i.a. teachers
         """
         return self._api.dict
 


### PR DESCRIPTION
Fixes #29

- Add `Vulcan.dictionaries` property with `Dictionaries` object
- Add new properties in `Dictionaries` class for getting teachers, subjects, etc.
- Add `position` attribute in `Subject` class
- Make tests for dictionaries