### PR TITLE
[Hotfix] Make grade category optional

### DIFF
--- a/vulcan/hebe/data/_grade.py
+++ b/vulcan/hebe/data/_grade.py
@@ -52,7 +52,7 @@ class GradeColumn(Serializable):
     number: int = IntegerField(key="Number")
     weight: float = FloatField(key="Weight")
     subject: Subject = ChildField(Subject, key="Subject")
-    category: GradeCategory = ChildField(GradeCategory, key="Category")
+    category: GradeCategory = ChildField(GradeCategory, key="Category", required=False)
 
     period: Period = ChildField(Period, key="Period", required=False)
 


### PR DESCRIPTION
Make grade category optional to avoid error like that:
```TypeError: ("'category' must be <class 'vulcan.hebe.data._grade.GradeCategory'> (got None that is a <class 'NoneType'>).", Attribute(name='category', default=NOTHING, validator=<instance_of validator for type <class 'vulcan.hebe.data._grade.GradeCategory'>>, repr=True, eq=True, order=True, hash=None, init=True, metadata=mappingproxy({'key': 'Category'}), type=<class 'vulcan.hebe.data._grade.GradeCategory'>, converter=<related.converters.to_child_field.<locals>.ChildConverter object at 0x7f818b5100>, kw_only=False), <class 'vulcan.hebe.data._grade.GradeCategory'>, None)```