### PR TITLE
Replace abandoned cchardet library

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         "aenum",
         "related",
         "aiohttp",
-        "cchardet",
+        "faust-cchardet",
         "aiodns",
         "yarl",
     ],


### PR DESCRIPTION
cchardet is abandoned https://docs.aiohttp.org/en/stable/#library-installation https://github.com/PyYoshi/cChardet/issues/77

There is a new active fork https://github.com/faust-streaming/cChardet that works on python3.11