### PR TITLE
Remove faust-cchardet dep

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ setup(
         "aenum",
         "related",
         "aiohttp",
-        "faust-cchardet",
         "aiodns",
         "yarl",
     ],


### PR DESCRIPTION
This lib was switched out in https://github.com/kapi2289/vulcan-api/pull/126 but since this lib is an optimization only and currently failing PEP 517 builds https://github.com/faust-streaming/cChardet/issues/22#issuecomment-1436051476, removing it per https://github.com/kapi2289/vulcan-api/pull/126#issuecomment-1436052635

@kapi2289 Apologizes for the additional churn