### PR TITLE
Add "content-type" header to API calls

### DIFF
--- a/vulcan/_api.py
+++ b/vulcan/_api.py
@@ -79,6 +79,7 @@ class Api:
         )
 
         headers = {
+            "content-type": "application/json",
             "User-Agent": APP_USER_AGENT,
             "vOS": APP_OS,
             "vDeviceModel": self._keystore.device_model,


### PR DESCRIPTION
adding this prevents from randomly getting html eduone page