### PR TITLE
Avoid loading old stunent profiles

### DIFF
--- a/vulcan/__init__.py
+++ b/vulcan/__init__.py
@@ -13,7 +13,7 @@ from ._exceptions import (
 )
 from ._keystore import Keystore
 
-__version__ = "2.3.2"
+__version__ = "2.3.3"
 __doc__ = "Unofficial API for UONET+ e-register"
 
 __all__ = [

--- a/vulcan/__init__.py
+++ b/vulcan/__init__.py
@@ -13,7 +13,7 @@ from ._exceptions import (
 )
 from ._keystore import Keystore
 
-__version__ = "2.3.3"
+__version__ = "2.3.2"
 __doc__ = "Unofficial API for UONET+ e-register"
 
 __all__ = [

--- a/vulcan/_api.py
+++ b/vulcan/_api.py
@@ -103,9 +103,7 @@ class Api:
         full_url = (
             url
             if url.startswith("http")
-            else self._rest_url + url
-            if self._rest_url
-            else None
+            else self._rest_url + url if self._rest_url else None
         )
 
         if not full_url:

--- a/vulcan/_client.py
+++ b/vulcan/_client.py
@@ -4,7 +4,7 @@ from typing import List
 from ._api import Api
 from ._data import VulcanData
 from ._utils import log
-from .model import Student
+from .model import State, Student
 
 
 class Vulcan:
@@ -50,15 +50,18 @@ class Vulcan:
         """
         log.setLevel(logging_level)
 
-    async def get_students(self, cached=True) -> List[Student]:
+    async def get_students(
+        self, state: State = State.ACTIVE, cached=True
+    ) -> List[Student]:
         """Gets students assigned to this account.
 
+        :param state: the state of the students to get
         :param bool cached: whether to allow returning the cached list
         :rtype: List[:class:`~vulcan.model.Student`]
         """
         if self._students and cached:
             return self._students
-        self._students = await Student.get(self._api)
+        self._students = await Student.get(self._api, state)
         return self._students
 
     @property

--- a/vulcan/_client.py
+++ b/vulcan/_client.py
@@ -4,7 +4,7 @@ from typing import List
 from ._api import Api
 from ._data import VulcanData
 from ._utils import log
-from .model import State, Student
+from .model import Student, StudentState
 
 
 class Vulcan:
@@ -51,7 +51,7 @@ class Vulcan:
         log.setLevel(logging_level)
 
     async def get_students(
-        self, state: State = State.ACTIVE, cached=True
+        self, state: StudentState = StudentState.ACTIVE, cached=True
     ) -> List[Student]:
         """Gets students assigned to this account.
 

--- a/vulcan/model/__init__.py
+++ b/vulcan/model/__init__.py
@@ -6,7 +6,7 @@ from ._period import Period
 from ._pupil import Gender, Pupil
 from ._school import School
 from ._serializable import Serializable
-from ._student import Student
+from ._student import State, Student
 from ._subject import Subject
 from ._teacher import Teacher
 from ._team import TeamClass, TeamVirtual

--- a/vulcan/model/__init__.py
+++ b/vulcan/model/__init__.py
@@ -6,7 +6,7 @@ from ._period import Period
 from ._pupil import Gender, Pupil
 from ._school import School
 from ._serializable import Serializable
-from ._student import State, Student
+from ._student import Student, StudentState
 from ._subject import Subject
 from ._teacher import Teacher
 from ._team import TeamClass, TeamVirtual

--- a/vulcan/model/_student.py
+++ b/vulcan/model/_student.py
@@ -76,4 +76,6 @@ class Student(Serializable):
         :rtype: List[:class:`~vulcan.model.Student`]
         """
         data = await api.get(STUDENT_LIST, **kwargs)
-        return [Student.load(student) for student in data if student["State"] == 0] # Ignore old student profiles that Vulcan started returning in their API
+        return [
+            Student.load(student) for student in data if student["State"] == 0
+        ]  # Ignore old student profiles that Vulcan started returning in their API

--- a/vulcan/model/_student.py
+++ b/vulcan/model/_student.py
@@ -12,7 +12,7 @@ from ._serializable import Serializable
 from ._unit import Unit
 
 
-class State(Enum):
+class StudentState(Enum):
     """Student state enumeration.
 
     :cvar int ACTIVE: active student
@@ -43,7 +43,7 @@ class Student(Serializable):
     class_: str = StringField(key="ClassDisplay")
     symbol: str = StringField(key="TopLevelPartition")
     symbol_code: str = StringField(key="Partition")
-    state: State = ChildField(State, key="State")
+    state: StudentState = ChildField(StudentState, key="State")
 
     pupil: Pupil = ChildField(Pupil, key="Pupil")
     unit: Unit = ChildField(Unit, key="Unit")

--- a/vulcan/model/_student.py
+++ b/vulcan/model/_student.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from enum import Enum
 from typing import List
 
 from related import ChildField, SequenceField, StringField, immutable
@@ -9,6 +10,17 @@ from ._pupil import Pupil
 from ._school import School
 from ._serializable import Serializable
 from ._unit import Unit
+
+
+class State(Enum):
+    """Student state enumeration.
+
+    :cvar int ACTIVE: active student
+    :cvar int INACTIVE: inactive student
+    """
+
+    ACTIVE = 0
+    INACTIVE = 3
 
 
 @immutable
@@ -31,6 +43,7 @@ class Student(Serializable):
     class_: str = StringField(key="ClassDisplay")
     symbol: str = StringField(key="TopLevelPartition")
     symbol_code: str = StringField(key="Partition")
+    state: State = ChildField(State, key="State")
 
     pupil: Pupil = ChildField(Pupil, key="Pupil")
     unit: Unit = ChildField(Unit, key="Unit")
@@ -71,11 +84,11 @@ class Student(Serializable):
         return next((period for period in self.periods if period.id == period_id), None)
 
     @classmethod
-    async def get(cls, api, **kwargs) -> List["Student"]:
+    async def get(cls, api, state, **kwargs) -> List["Student"]:
         """
         :rtype: List[:class:`~vulcan.model.Student`]
         """
         data = await api.get(STUDENT_LIST, **kwargs)
         return [
-            Student.load(student) for student in data if student["State"] == 0
-        ]  # Ignore old student profiles that Vulcan started returning in their API
+            Student.load(student) for student in data if student["State"] == state.value
+        ]

--- a/vulcan/model/_student.py
+++ b/vulcan/model/_student.py
@@ -76,4 +76,4 @@ class Student(Serializable):
         :rtype: List[:class:`~vulcan.model.Student`]
         """
         data = await api.get(STUDENT_LIST, **kwargs)
-        return [Student.load(student) for student in data]
+        return [Student.load(student) for student in data if student["State"] == 0] # Ignore old student profiles that Vulcan started returning in their API


### PR DESCRIPTION
Vulcan API now receives all old profiles (from previous schools) that are incomplete, this change filters them by "State" field